### PR TITLE
Replace sbt-utils with sbt-settings

### DIFF
--- a/project/PluginBuild.scala
+++ b/project/PluginBuild.scala
@@ -47,7 +47,7 @@ object PluginBuild extends Build {
       headers := HeaderSettings(),
       resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
       addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.0"),
-      addSbtPlugin("uk.gov.hmrc" % "sbt-utils" % "2.8.0"),
+      addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "3.2.0"),
       libraryDependencies ++= Seq(
         "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.7.0.201502260915-r",
         "org.scalatest" %% "scalatest" % "2.2.4" % "test",


### PR DESCRIPTION
It'll be importing the wrong version for downstream use of the auto-build plugin.

sbt-utils was renamed to sbt-settings and the change seems to have been missed in both the master and the 2.5 forks for this specific usage.